### PR TITLE
refactor: use molecule partial load to calculate inputs len

### DIFF
--- a/tests/src/tests.rs
+++ b/tests/src/tests.rs
@@ -38,7 +38,7 @@ fn test_failed_pubkey() {
     let mut witnesses = TypedMsgWitnesses::new(vec![3, 1, 2], others_witnesses);
     witnesses.set_with_action(1);
     witnesses.typed_msg_datas[2].config_failed_pubkey_hash = true;
-    
+
     witnesses.update();
 
     // deploy contract


### PR DESCRIPTION
The molecule table is serialized into 2 parts: [the header and the body](https://github.com/nervosnetwork/molecule/blob/master/docs/encoding_spec.md#memory-layout) , we can easily calculate the length of a specific field from the offsets, so that we can call syscall only once to calculate the number of inputs.